### PR TITLE
Request handler refactoring

### DIFF
--- a/datafetcher/handlers/accounts.go
+++ b/datafetcher/handlers/accounts.go
@@ -1,0 +1,42 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/esteanes/expense-manager/datafetcher/upclient"
+)
+
+type AccountHandler struct {
+	*BaseHandler
+}
+
+func NewAccountHandler(log *log.Logger, upclient *upclient.APIClient, auth context.Context) *AccountHandler {
+	handler := &AccountHandler{}
+	handler.BaseHandler = &BaseHandler{
+		Uri:      "/accounts",
+		Log:      log,
+		UpClient: upclient,
+		UpAuth:   auth,
+		Handler:  handler, // Set the Handler interface to the specific handler
+	}
+	return handler
+}
+
+func (h *AccountHandler) Post(w http.ResponseWriter, r *http.Request) {}
+func (h *AccountHandler) Get(w http.ResponseWriter, r *http.Request) {
+	pageSize := int32(30)
+	filterAccountType := upclient.AccountTypeEnum("SAVER")
+	filterOwnershipType := upclient.OwnershipTypeEnum("INDIVIDUAL")
+	resp, r2, err := h.UpClient.AccountsAPI.AccountsGet(h.UpAuth).PageSize(pageSize).FilterAccountType(filterAccountType).FilterOwnershipType(filterOwnershipType).Execute()
+	
+	if err != nil {
+		fmt.Fprintf(w, "Error when calling `AccountsAPI.AccountsGet``: %v\n", err)
+		fmt.Fprintf(w, "Full HTTP response: %v\n", r2)
+		h.Log.Println("Unable to get account information")
+	}
+
+	fmt.Fprintf(w, "Response from `AccountsAPI.AccountsGet`: %v\n", resp)
+}

--- a/datafetcher/handlers/basehandler.go
+++ b/datafetcher/handlers/basehandler.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"context"
+	"log"
+	"net/http"
+
+	"github.com/esteanes/expense-manager/datafetcher/upclient"
+)
+
+type Handler interface {
+	Post(w http.ResponseWriter, r *http.Request)
+	Get(w http.ResponseWriter, r *http.Request)
+}
+
+type BaseHandler struct {
+	Uri      string
+	Log      *log.Logger
+	UpClient *upclient.APIClient
+	UpAuth   context.Context
+	Handler  Handler // Embed the Handler interface
+}
+
+func (h *BaseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		h.Handler.Post(w, r)
+	case http.MethodGet:
+		h.Handler.Get(w, r)
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}

--- a/datafetcher/handlers/transactions.go
+++ b/datafetcher/handlers/transactions.go
@@ -1,0 +1,39 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/esteanes/expense-manager/datafetcher/upclient"
+)
+
+type TransactionsHandler struct {
+	*BaseHandler
+}
+
+func NewTransactionHandler(log *log.Logger, upclient *upclient.APIClient, auth context.Context) *AccountHandler {
+	handler := &AccountHandler{}
+	handler.BaseHandler = &BaseHandler{
+		Uri:      "/transactions",
+		Log:      log,
+		UpClient: upclient,
+		UpAuth:   auth,
+		Handler:  handler, // Set the Handler interface to the specific handler
+	}
+	return handler
+}
+
+func (h *TransactionsHandler) Post(w http.ResponseWriter, r *http.Request) {}
+func (h *TransactionsHandler) Get(w http.ResponseWriter, r *http.Request) {
+	pageSize := int32(30) // int32 | The number of records to return in each page.  (optional)
+	resp2, r2, err := h.UpClient.TransactionsAPI.TransactionsGet(h.UpAuth).PageSize(pageSize).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error when calling `TransactionsAPI.TransactionsGet``: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r2.Body)
+	}
+	// response from `TransactionsGet`: ListTransactionsResponse
+	fmt.Fprintf(os.Stdout, "Response from `TransactionsAPI.TransactionsGet`: %v\n", resp2)
+}


### PR DESCRIPTION
I wanted to set up a baseline handler that we can use as an interface for all requests going forward.
* Consistency through the interface and common struct
* Encapsulation - everything endpoint specific is defined within the endpoint file
* Extensibility - if we want to add other request types it shouldn't be an issue.