### PR TITLE
Trying to get gh actions to work properly again

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,6 +21,17 @@ jobs:
       with:
         go-version: '1.21.5'
 
+    - name: Cache Go modules
+      uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - name: Install dependencies
+      run: go mod download
+
     - name: Build
       run: go build -v ./...
 


### PR DESCRIPTION
Courtesy of ChatGPT - was facing some issues: 

```
Run go build -v ./...
go: downloading github.com/a-h/templ v0.2.747
go: downloading github.com/alexedwards/scs/v2 v2.8.0
Error: datafetcher/server.go:11:2: no required module provides package github.com/esteanes/expense-manager/datafetcher/handlers; to add it:
	go get github.com/esteanes/expense-manager/datafetcher/handlers
Error: Process completed with exit code 1.
```